### PR TITLE
slackify image with no alt-title

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -86,6 +86,12 @@ test('Image with alt-title', () => {
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
+test('Image with no alt-title', () => {
+  const mrkdown = '![](https://bitbucket.org/repo/123/images/logo.png)';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
 test('Image with invalid link', () => {
   const mrkdown = "![logo.png](/relative-path-logo.png 'test')";
   const slack = '/relative-path-logo.png\n';

--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -88,7 +88,7 @@ test('Image with alt-title', () => {
 
 test('Image with no alt-title', () => {
   const mrkdown = '![](https://bitbucket.org/repo/123/images/logo.png)';
-  const slack = '<https://bitbucket.org/repo/123/images/logo.png|>\n';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -53,7 +53,7 @@ const visitors = {
   url(node, text) {
     const url = this.encode(node.url || '', node);
     if (!isURL(url)) return url;
-    return `<${url}|${text || ''}>`;
+    return text ? `<${url}|${text}>` : `<${url}>`;
   },
 };
 

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -53,7 +53,7 @@ const visitors = {
   url(node, text) {
     const url = this.encode(node.url || '', node);
     if (!isURL(url)) return url;
-    return `<${url}|${text}>`;
+    return `<${url}|${text || ''}>`;
   },
 };
 


### PR DESCRIPTION
Before:
`![](https://bitbucket.org/repo/123/images/logo.png)` processed as `<https://bitbucket.org/repo/123/images/logo.png|null>`
Now: 
`<https://bitbucket.org/repo/123/images/logo.png>`