### PR TITLE
Make text replace newlines with spaces

### DIFF
--- a/src/slackify.js
+++ b/src/slackify.js
@@ -54,6 +54,10 @@ const visitors = {
     if (!isURL(url)) return url;
     return text ? `<${url}|${text}>` : `<${url}>`;
   },
+
+  text({ value: text }) {
+    return text.replace(/\n/g, ' ');
+  },
 };
 
 class SlackCompiler extends Compiler {


### PR DESCRIPTION
Full test case incoming, but this is to fix the situation that we were running into where if an anchor had a newline in it, it wouldn't convert the anchor. This just turns the newline into a whitespace if it shows up in a text node. It doesn't break all newlines, I'm assuming by this function call it's already converted the typical newlines into other node types, and this is only when the parser assumes it's text.

It might not be the best solution given the docs on [common mark](https://github.com/remarkjs/remark/tree/main/packages/remark-parse#optionscommonmark) option lead me to believe that newlines in anchor text are actually valid... not sure if that means it renders them as a line break or just that they're valid.