### PR TITLE
Fix TypeScript export declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare module "slackify-markdown" {
   function slackify(markdown: string): string;
-  export default slackify;
+  export = slackify;
 }


### PR DESCRIPTION
The module was incorrectly stating that there's a `default` export,
which is not true of the actual code (wherein it has a `module.exports`
equal to the entrypoint).

You can recreate this fairly easily with the following:

tsconfig.json

```json
{
  "compilerOptions": {
    "target": "es2019",
    "module": "commonjs",
    "moduleResolution": "node"
  }
}
```

index.ts

```ts
import slackifyMarkdown from 'slackify-markdown'

slackifyMarkdown('test')
```

This will pass TypeScript compilation, but will fail at runtime because the compiled JavaScript will be looking for a `.default` property on the module, which is not present.

With this commit applied, tsconfig will require `"esModuleInterop": true` to pass compilation in the first place, and will work at runtime.
