### PR TITLE
Prefer alt text in links and images

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -57,14 +57,20 @@ test('Ordered list', () => {
 });
 
 test('Link with title', () => {
+  const mrkdown = '[](http://atlassian.com "Atlassian")';
+  const slack = '<http://atlassian.com|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link with alt', () => {
   const mrkdown = '[test](http://atlassian.com)';
   const slack = '<http://atlassian.com|test>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
-test('Link with alt', () => {
+test('Link with alt and title', () => {
   const mrkdown = '[test](http://atlassian.com "Atlassian")';
-  const slack = '<http://atlassian.com|Atlassian>\n';
+  const slack = '<http://atlassian.com|test>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
@@ -74,7 +80,7 @@ test('Link with angle bracket syntax', () => {
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
-test('Link with no title nor alt', () => {
+test('Link with no alt nor title', () => {
   const mrkdown = '[](http://atlassian.com)';
   const slack = '<http://atlassian.com>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
@@ -82,19 +88,25 @@ test('Link with no title nor alt', () => {
 
 test('Link with invalid URL', () => {
   const mrkdown = '[test](/atlassian)';
-  const slack = '/atlassian\n';
+  const slack = 'test\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
 test('Image with title', () => {
+  const mrkdown = '![](https://bitbucket.org/repo/123/images/logo.png "test")';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|test>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image with alt', () => {
   const mrkdown = '![logo.png](https://bitbucket.org/repo/123/images/logo.png)';
   const slack = '<https://bitbucket.org/repo/123/images/logo.png|logo.png>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
-test('Image with alt', () => {
+test('Image with alt and title', () => {
   const mrkdown = "![logo.png](https://bitbucket.org/repo/123/images/logo.png 'test')";
-  const slack = '<https://bitbucket.org/repo/123/images/logo.png|test>\n';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|logo.png>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
@@ -106,7 +118,7 @@ test('Image with no alt nor title', () => {
 
 test('Image with invalid URL', () => {
   const mrkdown = "![logo.png](/relative-path-logo.png 'test')";
-  const slack = '/relative-path-logo.png\n';
+  const slack = 'logo.png\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -66,23 +66,23 @@ const handlers = {
 
   link: (node, _parent, context) => {
     const exit = context.enter('link');
-    const text = node.title
-      || phrasing(node, context, { before: '|', after: '>' });
+    const text = phrasing(node, context, { before: '|', after: '>' })
+      || node.title;
     const url = encodeURI(node.url);
     exit();
 
-    if (!isURL(url)) return url;
+    if (!isURL(url)) return text || url;
 
     return text ? `<${url}|${text}>` : `<${url}>`;
   },
 
   image: (node, _parent, context) => {
     const exit = context.enter('image');
-    const text = node.title || node.alt;
+    const text = node.alt || node.title;
     const url = encodeURI(node.url);
     exit();
 
-    if (!isURL(url)) return url;
+    if (!isURL(url)) return text || url;
 
     return text ? `<${url}|${text}>` : `<${url}>`;
   },


### PR DESCRIPTION
This looks to overturn a couple of decisions made in slackify-markdown. While I can see arguments both ways, I reckon that the proposed changes are less surprising as default behaviour:

1. Render an invalid link with its alt text before its URL.

   The URL isn't valid anyway, and the alt text will likely flow better in its sentence.

2. Label a link with its alt text before its title.

   If we look at how GitHub renders Markdown, the alt text is chosen as the label, and the title corresponds to the HTML attribute of the same name and manifests as a tooltip. We are not afforded a similar attribute with Slack, so the title is only useful as a fallback.

---

Given this source:

````markdown
By continuing you agree to our [terms of use](../terms).

Lost? You can always return to our [homepage](https://www.atlassian.com "Atlassian.com").
````

Current output:

> By continuing you agree to our ../terms.
> 
> Lost? You can always return to our [Atlassian.com](https://www.atlassian.com).

Proposed output:

> By continuing you agree to our terms of use.
> 
> Lost? You can always return to our [homepage](https://www.atlassian.com).