### PR TITLE
Handle link and image references

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -57,14 +57,20 @@ test('Ordered list', () => {
 });
 
 test('Link with title', () => {
+  const mrkdown = '[](http://atlassian.com "Atlassian")';
+  const slack = '<http://atlassian.com|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link with alt', () => {
   const mrkdown = '[test](http://atlassian.com)';
   const slack = '<http://atlassian.com|test>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
-test('Link with alt', () => {
+test('Link with alt and title', () => {
   const mrkdown = '[test](http://atlassian.com "Atlassian")';
-  const slack = '<http://atlassian.com|Atlassian>\n';
+  const slack = '<http://atlassian.com|test>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
@@ -74,7 +80,7 @@ test('Link with angle bracket syntax', () => {
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
-test('Link with no title nor alt', () => {
+test('Link with no alt nor title', () => {
   const mrkdown = '[](http://atlassian.com)';
   const slack = '<http://atlassian.com>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
@@ -82,19 +88,25 @@ test('Link with no title nor alt', () => {
 
 test('Link with invalid URL', () => {
   const mrkdown = '[test](/atlassian)';
-  const slack = '/atlassian\n';
+  const slack = 'test\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
 test('Image with title', () => {
+  const mrkdown = '![](https://bitbucket.org/repo/123/images/logo.png "test")';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|test>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image with alt', () => {
   const mrkdown = '![logo.png](https://bitbucket.org/repo/123/images/logo.png)';
   const slack = '<https://bitbucket.org/repo/123/images/logo.png|logo.png>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
-test('Image with alt', () => {
+test('Image with alt and title', () => {
   const mrkdown = "![logo.png](https://bitbucket.org/repo/123/images/logo.png 'test')";
-  const slack = '<https://bitbucket.org/repo/123/images/logo.png|test>\n';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|logo.png>\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
@@ -106,7 +118,7 @@ test('Image with no alt nor title', () => {
 
 test('Image with invalid URL', () => {
   const mrkdown = "![logo.png](/relative-path-logo.png 'test')";
-  const slack = '/relative-path-logo.png\n';
+  const slack = 'logo.png\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 

--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -10,6 +10,12 @@ test('Escaped text', () => {
   expect(slackifyMarkdown('*h&ello>world<')).toBe('*h&amp;ello&gt;world&lt;\n');
 });
 
+test('Definitions', () => {
+  const mrkdown = 'hello\n\n[1]: http://atlassian.com\n\nworld\n\n[2]: http://atlassian.com';
+  const slack = 'hello\n\nworld\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
 test('Headings', () => {
   const mrkdown = '# heading 1\n## heading 2\n### heading 3';
   const slack = '*heading 1*\n\n*heading 2*\n\n*heading 3*\n';
@@ -92,6 +98,42 @@ test('Link with invalid URL', () => {
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
+test('Link in reference style with alt', () => {
+  const mrkdown = '[Atlassian]\n\n[atlassian]: http://atlassian.com';
+  const slack = '<http://atlassian.com|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link in reference style with custom label', () => {
+  const mrkdown = '[][test]\n\n[test]: http://atlassian.com';
+  const slack = '<http://atlassian.com>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link in reference style with alt and custom label', () => {
+  const mrkdown = '[Atlassian][test]\n\n[test]: http://atlassian.com';
+  const slack = '<http://atlassian.com|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link in reference style with title', () => {
+  const mrkdown = '[][test]\n\n[test]: http://atlassian.com "Title"';
+  const slack = '<http://atlassian.com|Title>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link in reference style with alt and title', () => {
+  const mrkdown = '[Atlassian]\n\n[atlassian]: http://atlassian.com "Title"';
+  const slack = '<http://atlassian.com|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Link in reference style with invalid definition', () => {
+  const mrkdown = '[Atlassian][test]\n\n[test]: /atlassian';
+  const slack = 'Atlassian\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
 test('Image with title', () => {
   const mrkdown = '![](https://bitbucket.org/repo/123/images/logo.png "test")';
   const slack = '<https://bitbucket.org/repo/123/images/logo.png|test>\n';
@@ -122,6 +164,42 @@ test('Image with invalid URL', () => {
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
+test('Image in reference style with alt', () => {
+  const mrkdown = '![Atlassian]\n\n[atlassian]: https://bitbucket.org/repo/123/images/logo.png';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image in reference style with custom label', () => {
+  const mrkdown = '![][test]\n\n[test]: https://bitbucket.org/repo/123/images/logo.png';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image in reference style with alt and custom label', () => {
+  const mrkdown = '![Atlassian][test]\n\n[test]: https://bitbucket.org/repo/123/images/logo.png';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image in reference style with title', () => {
+  const mrkdown = '![][test]\n\n[test]: https://bitbucket.org/repo/123/images/logo.png "Title"';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|Title>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image in reference style with alt and title', () => {
+  const mrkdown = '![Atlassian]\n\n[atlassian]: https://bitbucket.org/repo/123/images/logo.png "Title"';
+  const slack = '<https://bitbucket.org/repo/123/images/logo.png|Atlassian>\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Image in reference style with invalid definition', () => {
+  const mrkdown = '![Atlassian][test]\n\n[test]: /relative-path-logo.png';
+  const slack = 'Atlassian\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
 test('Inline code', () => {
   const mrkdown = 'hello `world`';
   const slack = 'hello `world`\n';
@@ -131,6 +209,12 @@ test('Inline code', () => {
 test('Code block', () => {
   const mrkdown = '```\ncode block\n```';
   const slack = '```\ncode block\n```\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
+test('Code block with newlines', () => {
+  const mrkdown = '```\ncode\n\n\nblock\n```';
+  const slack = '```\ncode\n\n\nblock\n```\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "remark-gfm": "^1.0.0",
     "remark-parse": "^9.0.0",
     "remark-stringify": "^9.0.1",
-    "unified": "^9.0.0"
+    "unified": "^9.0.0",
+    "unist-util-remove": "^2.0.1",
+    "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {
     "codecov": "^3.7.0",

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -1,0 +1,30 @@
+const remove = require('unist-util-remove');
+const visit = require('unist-util-visit');
+
+/**
+ * Fills the provided record with `Definition`s contained in the mdast.
+ * They are keyed by identifier for subsequent `Reference` lookups.
+ *
+ * @param {Record<string, { title: null | string, url: string }>} definitions
+ */
+const collectDefinitions = definitions => tree => {
+  visit(tree, 'definition', node => {
+    definitions[node.identifier] = {
+      title: node.title,
+      url: node.url,
+    };
+  });
+};
+
+/**
+ * Removes `Definition`s and their parent `Paragraph`s from the mdast.
+ * This avoids unwanted negative space in stringified output.
+ */
+const removeDefinitions = () => tree => {
+  remove(tree, { cascade: true }, 'definition');
+};
+
+module.exports = {
+  collectDefinitions,
+  removeDefinitions,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,23 @@ const gfm = require('remark-gfm');
 const parse = require('remark-parse');
 const stringify = require('remark-stringify');
 const unified = require('unified');
-const slackifyOptions = require('./slackify');
 
-module.exports = (markdown, options) => unified()
-  .use(parse, options)
-  // Delete node is defined in GFM
-  // https://github.com/syntax-tree/mdast/blob/main/readme.md#gfm
-  .use(gfm)
-  .use(stringify, slackifyOptions)
-  .processSync(markdown)
-  .toString();
+const { collectDefinitions, removeDefinitions } = require('./definitions');
+const createSlackifyOptions = require('./slackify');
+
+module.exports = (markdown, options) => {
+  const definitions = {};
+
+  const slackifyOptions = createSlackifyOptions(definitions);
+
+  return unified()
+    .use(parse, options)
+    // Delete node is defined in GFM
+    // https://github.com/syntax-tree/mdast/blob/main/readme.md#gfm
+    .use(gfm)
+    .use(collectDefinitions, definitions)
+    .use(removeDefinitions)
+    .use(stringify, slackifyOptions)
+    .processSync(markdown)
+    .toString();
+};

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -66,23 +66,23 @@ const handlers = {
 
   link: (node, _parent, context) => {
     const exit = context.enter('link');
-    const text = node.title
-      || phrasing(node, context, { before: '|', after: '>' });
+    const text = phrasing(node, context, { before: '|', after: '>' })
+      || node.title;
     const url = encodeURI(node.url);
     exit();
 
-    if (!isURL(url)) return url;
+    if (!isURL(url)) return text || url;
 
     return text ? `<${url}|${text}>` : `<${url}>`;
   },
 
   image: (node, _parent, context) => {
     const exit = context.enter('image');
-    const text = node.title || node.alt;
+    const text = node.alt || node.title;
     const url = encodeURI(node.url);
     exit();
 
-    if (!isURL(url)) return url;
+    if (!isURL(url)) return text || url;
 
     return text ? `<${url}|${text}>` : `<${url}>`;
   },


### PR DESCRIPTION
This adds handlers for the ImageReference and LinkReference nodes to resolve them down to Slack-compatible links. It doesn't seem possible to look up Definition nodes from the handler arguments, so we crawl the AST beforehand to manually build up our own record, then remove the nodes so that they do not clog up the output with awkward newlines.

Relevant nodes:

- https://github.com/syntax-tree/mdast/blob/main/readme.md#definition
- https://github.com/syntax-tree/mdast/blob/main/readme.md#linkreference
- https://github.com/syntax-tree/mdast/blob/main/readme.md#imagereference

---

This is currently built on top of #20, but I can rebase this on master if you don't want to go ahead with that change.