### PR TITLE
Preserve mentions formatting

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -229,3 +229,10 @@ test('Code block with deprecated language declaration', () => {
   const slack = '```\ncode block\n```\n';
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
+
+test('User mention', () => {
+  const mrkdown = '<@UPXGB22A2>';
+  const slack = '<@UPXGB22A2>\n';
+
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -122,8 +122,8 @@ const createHandlers = definitions => ({
     // https://api.slack.com/reference/surfaces/formatting#escaping
     const text = node.value
       .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+      .replace(/<(?!@)/g, '&lt;')
+      .replace(/(?<!@[A-Z0-9]+)>/g, '&gt;');
     exit();
 
     // Do we need more escaping like the default handler uses?


### PR DESCRIPTION
This format is mentioned in https://api.slack.com/changelog/2017-09-the-one-about-usernames

> Using link_names when posting messages is also deprecated. We'll continue matching @mentions with usernames, but for now please mention users with the <@W123> user ID format instead.

---

Let me know if I need to adjust anything