### PR TITLE
FIX: use builtin URL parser

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-const { URL } = require('url');
-
 module.exports = {
   wrap(string, ...wrappers) {
     return [


### PR DESCRIPTION
Depending on the environment, `const { URL } = require('url')` may clash with the [url](https://github.com/defunctzombie/node-url/blob/master/url.js) package used by `webpack-dev-server`, importing a function instead of a class, making `isURL` always return false due to `TypeError: URL is not a constructor`.

Using the builtin `URL` class seems to be working equally fine in the browser and node as well.