### PR TITLE
Check for already encoded URIs

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -128,6 +128,12 @@ test('Link in reference style with alt and title', () => {
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
 
+test('Link is already encoded', () => {
+  const mrkdown = '[Atlassian](https://www.atlassian.com?redirect=https%3A%2F%2Fwww.asana.com): /atlassian';
+  const slack = '<https://www.atlassian.com?redirect=https%3A%2F%2Fwww.asana.com|Atlassian>: /atlassian\n';
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});
+
 test('Link in reference style with invalid definition', () => {
   const mrkdown = '[Atlassian][test]\n\n[test]: /atlassian';
   const slack = 'Atlassian\n';

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -1,7 +1,7 @@
 const defaultHandlers = require('mdast-util-to-markdown/lib/handle');
 const phrasing = require('mdast-util-to-markdown/lib/util/container-phrasing');
 
-const { wrap, isURL } = require('./utils');
+const { wrap, isURL, isPotentiallyEncoded } = require('./utils');
 
 // fixes slack in-word formatting (e.g. hel*l*o)
 const zeroWidthSpace = String.fromCharCode(0x200B);
@@ -74,7 +74,7 @@ const createHandlers = definitions => ({
     const exit = context.enter('link');
     const text = phrasing(node, context, { before: '|', after: '>' })
       || node.title;
-    const url = encodeURI(node.url);
+    const url = isPotentiallyEncoded(node.url) ? node.url :  encodeURI(node.url);
     exit();
 
     if (!isURL(url)) return text || url;

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -74,7 +74,7 @@ const createHandlers = definitions => ({
     const exit = context.enter('link');
     const text = phrasing(node, context, { before: '|', after: '>' })
       || node.title;
-    const url = isPotentiallyEncoded(node.url) ? node.url :  encodeURI(node.url);
+    const url = isPotentiallyEncoded(node.url) ? node.url : encodeURI(node.url);
     exit();
 
     if (!isURL(url)) return text || url;

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,6 @@ module.exports = {
   },
 
   isPotentiallyEncoded(uri) {
-    return uri !== decodeURIComponent(uri || "");
+    return uri !== decodeURIComponent(uri || '');
   },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,4 +14,8 @@ module.exports = {
       return false;
     }
   },
+
+  isPotentiallyEncoded(uri) {
+    return uri !== decodeURIComponent(uri || "");
+  },
 };


### PR DESCRIPTION
I had the problem that I added a Link with a query parameter which was already url encoded. That's why I added the check before the `encodeURI` call if the `node.url` was already encoded.