### PR TITLE
Add support for mentioning channels by ID. e.g. <#C04A9JK5R3Z>

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -242,3 +242,10 @@ test('User mention', () => {
 
   expect(slackifyMarkdown(mrkdown)).toBe(slack);
 });
+
+test('Channel mention', () => {
+  const mrkdown = '<#C04A9JK5R3Z>';
+  const slack = '<#C04A9JK5R3Z>\n';
+
+  expect(slackifyMarkdown(mrkdown)).toBe(slack);
+});

--- a/src/slackify.js
+++ b/src/slackify.js
@@ -9,9 +9,9 @@ const zeroWidthSpace = String.fromCharCode(0x200B);
 const escapeSpecials = text => {
   const escaped = text
     .replace(/&/g, '&amp;')
-    .replace(/<([^@]|$)/g, (_, m) => `&lt;${m}`)
+    .replace(/<([^@#]|$)/g, (_, m) => `&lt;${m}`)
     .replace(/^(.*)>/g, (_, m) => {
-      const isEndOfUserMention = Boolean(m.match(/<@[A-Z0-9]+$/));
+      const isEndOfUserMention = Boolean(m.match(/<[@#][A-Z0-9]+$/));
       if (isEndOfUserMention) {
         return `${m}>`;
       }


### PR DESCRIPTION
Similar to user mentions, Slack supports mentioning channels via their ID. For example `<#C04A9JK5R3Z>` will be transformed to `#general`. This PR adds the `#` prefix to the existing `@` prefix in the regex for checking user mentions, so that the angle brackets don't get escaped. Test included. 